### PR TITLE
fix a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Function-as-a-Service (FaaS) based on Kubernetes Jobs
 
 # How to build and run
-In go-exec directory, run
+In go-kexec directory, run
 ```
 go install
 ```


### PR DESCRIPTION
I think it should be `go-kexec directory` not `go-exec directory`